### PR TITLE
docs: уточнить формулировки после PR #33

### DIFF
--- a/.memory_bank/gameplay-mvp-review.md
+++ b/.memory_bank/gameplay-mvp-review.md
@@ -207,7 +207,7 @@
 **Файлы:**
 - `server/src/rooms/ArenaRoom.ts` (Last Breath логика в processCombat, deathSystem, flightAssistSystem)
 - `config/balance.json` (combat.lastBreathDurationSec, lastBreathSpeedPenalty)
-- `client/src/main.ts` (строка 4389: отображение индикатора "LB")
+- `client/src/main.ts` (отрисовка: индикатор "LB" под именем игрока)
 
 ---
 


### PR DESCRIPTION
Уточнение документации без изменения кода:
- TECH_DEBT.md: исправлена формулировка про рост числа проверок и уточнён подход к кэшу зоны без добавления полей в Colyseus Schema.
- .memory_bank/gameplay-mvp-review.md: убрана привязка к номеру строки для индикатора Last Breath.