### PR TITLE
Sprint 10: Pre-Launch Fixes

### DIFF
--- a/.memory_bank/activeContext.md
+++ b/.memory_bank/activeContext.md
@@ -6,10 +6,21 @@
 **База:** main (8 января 2026)
 **Релиз:** v0.3.4
 **GDD версия:** 3.3.2
-**Текущая ветка:** main
+**Текущая ветка:** sprint-10/pre-launch-fixes
 **Soft Launch Status:** ✅ READY (6/6 критериев выполнено)
 
 ### Фокус сессии
+
+- **[В РАБОТЕ] Sprint 10: Pre-Launch Fixes:**
+  - ✅ 10.1: slime-arena-8yz — имя обновляется при replay (onPlay → selectClass с name)
+  - ✅ 10.2: slime-arena-6hn — LEVEL_THRESHOLDS из balance.json (GameHUD использует конфиг)
+  - ⏳ 10.3: PR, merge
+
+- **[ЗАВЕРШЕНО] Sprint 9: Architect Analysis (Soft Launch Readiness):**
+  - ✅ Анализ SlimeArena-SoftLaunch-Plan-v1.0.5.md
+  - ✅ 6/6 обязательных критериев выполнено
+  - ✅ Создано 3 A/B Mobile Controls задачи для post-launch
+  - ❌ Beads MCP Server (blocked: нет /plugin команд в Claude Code)
 
 - **[ЗАВЕРШЕНО] Sprint 8: joinToken JWT Validation (PR #52):**
   - ✅ 8.1: JoinTokenService — генерация и верификация JWT токенов

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -4049,9 +4049,9 @@ function leaveRoomFromUI(): void {
 // Initialize Preact UI
 const uiCallbacks: UICallbacks = {
     onPlay: (name: string, classId: number) => {
-        // Если уже подключены к комнате (между матчами), отправить selectClass
+        // Если уже подключены к комнате (между матчами), отправить selectClass с именем
         if (activeRoom) {
-            activeRoom.send("selectClass", { classId });
+            activeRoom.send("selectClass", { classId, name });
             setPhase("waiting");
             return;
         }

--- a/client/src/ui/components/GameHUD.tsx
+++ b/client/src/ui/components/GameHUD.tsx
@@ -5,6 +5,7 @@
 
 import { Fragment } from 'preact';
 import { useEffect, useState } from 'preact/hooks';
+import { DEFAULT_BALANCE_CONFIG } from '@slime-arena/shared';
 import { injectStyles } from '../utils/injectStyles';
 import {
   localPlayer,
@@ -221,8 +222,9 @@ function formatMass(mass: number): string {
   return Math.floor(mass).toString();
 }
 
-// Пороги массы для уровней (GDD v3.3)
-const LEVEL_THRESHOLDS = [0, 100, 180, 300, 500, 800, 1200];
+// Пороги массы для уровней из конфига (GDD v3.3)
+// Добавляем 0 в начало для расчёта прогресса уровня 1
+const LEVEL_THRESHOLDS = [0, ...DEFAULT_BALANCE_CONFIG.slime.levelThresholds];
 
 /**
  * Вычисляет прогресс до следующего уровня (0-100%)

--- a/server/src/rooms/ArenaRoom.ts
+++ b/server/src/rooms/ArenaRoom.ts
@@ -171,7 +171,7 @@ export class ArenaRoom extends Room<GameState> {
         this.state.timeRemaining = this.balance.match.durationSec;
         this.generateArena();
 
-        this.onMessage("selectClass", (client, data: { classId?: unknown }) => {
+        this.onMessage("selectClass", (client, data: { classId?: unknown; name?: unknown }) => {
             const player = this.state.players.get(client.sessionId);
             if (!player) return;
             if (this.isMatchEnded || this.state.phase === "Results") return;
@@ -184,6 +184,12 @@ export class ArenaRoom extends Room<GameState> {
             if (!Number.isInteger(rawClassId) || rawClassId < 0 || rawClassId > 2) return;
 
             player.classId = rawClassId;
+
+            // Обновляем имя игрока, если передано (для replay между матчами)
+            const newName = (data as any)?.name;
+            if (typeof newName === "string" && newName.trim().length > 0) {
+                player.name = newName.trim().slice(0, 24);
+            }
 
             const classAbilities = ["dash", "shield", "pull"];
             player.abilitySlot0 = classAbilities[player.classId] || "dash";


### PR DESCRIPTION
## Summary
- Fix name not updating on match replay (slime-arena-8yz)
- Use balance config for LEVEL_THRESHOLDS instead of hardcoded values (slime-arena-6hn)

## Changes
- **client/src/main.ts**: Include `name` in `selectClass` message when replaying
- **server/src/rooms/ArenaRoom.ts**: Handle `name` field in `selectClass` handler
- **client/src/ui/components/GameHUD.tsx**: Import `DEFAULT_BALANCE_CONFIG` and use `levelThresholds` from config

## Test plan
- [x] TypeScript build passes
- [x] Determinism tests pass
- [x] Orb bite tests pass
- [x] Arena generation tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)