### PR TITLE
fix: pass visual config through resolveBalanceConfig

### DIFF
--- a/shared/src/config.ts
+++ b/shared/src/config.ts
@@ -3037,6 +3037,8 @@ export function resolveBalanceConfig(raw: unknown): ResolvedBalanceConfig {
                 classTalents: parseClassTalents(classTalents, DEFAULT_BALANCE_CONFIG.talents.classTalents),
             };
         })(),
+        // Передаём visual как есть (клиентская визуализация)
+        visual: isRecord(data.visual) ? data.visual as BalanceConfig["visual"] : undefined,
     };
 
     const globalCooldownTicks = Math.max(


### PR DESCRIPTION
## Summary
- P1 баг: секция `visual` не передавалась через `resolveBalanceConfig()`
- Клиент не получал настройки визуализации (сектор рта, стрелка ввода)
- Исправлено добавлением `visual` в resolved объект

## Изменения
- [shared/src/config.ts](shared/src/config.ts#L3040-L3041) — добавлена передача visual

## Test plan
- [x] `npm run build` — ✅ проходит
- [x] `npm run test` — ✅ детерминизм сохранён
- [ ] Ручная проверка: визуализация сектора рта и стрелки ввода работает

## Связанные задачи
- Fixes: slime-arena-0ih
- Источник: Codex ревью PR #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)