### PR TITLE
docs(docker): add OCI labels with multi-platform description

### DIFF
--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -2,7 +2,16 @@
 # Slime Arena Monolith Container
 # Multi-stage production build for MetaServer + MatchServer + Client
 # Version: 0.5.2
+# Platforms: linux/amd64, linux/arm64
 # =============================================================================
+
+# OCI Image Labels
+LABEL org.opencontainers.image.title="Slime Arena App"
+LABEL org.opencontainers.image.description="Slime Arena game server bundle: MetaServer + MatchServer + Client. Multi-platform support: AMD64 (Intel/AMD) and ARM64 (Apple Silicon M1-M4, AWS Graviton)."
+LABEL org.opencontainers.image.vendor="komleff"
+LABEL org.opencontainers.image.source="https://github.com/komleff/slime-arena"
+LABEL org.opencontainers.image.documentation="https://github.com/komleff/slime-arena#docker"
+LABEL org.opencontainers.image.licenses="MIT"
 
 # -----------------------------------------------------------------------------
 # Stage 1: Builder

--- a/docker/db.Dockerfile
+++ b/docker/db.Dockerfile
@@ -2,7 +2,16 @@
 # Slime Arena DB Container
 # PostgreSQL + Redis in one container
 # Version: 0.5.2
+# Platforms: linux/amd64, linux/arm64
 # =============================================================================
+
+# OCI Image Labels
+LABEL org.opencontainers.image.title="Slime Arena DB"
+LABEL org.opencontainers.image.description="Slime Arena database bundle: PostgreSQL 16 + Redis. Multi-platform support: AMD64 (Intel/AMD) and ARM64 (Apple Silicon M1-M4, AWS Graviton)."
+LABEL org.opencontainers.image.vendor="komleff"
+LABEL org.opencontainers.image.source="https://github.com/komleff/slime-arena"
+LABEL org.opencontainers.image.documentation="https://github.com/komleff/slime-arena#docker"
+LABEL org.opencontainers.image.licenses="MIT"
 
 FROM alpine:3.19
 

--- a/docker/monolith-full.Dockerfile
+++ b/docker/monolith-full.Dockerfile
@@ -2,7 +2,16 @@
 # Slime Arena Monolith Full Container
 # All-in-One: PostgreSQL + Redis + MetaServer + MatchServer + Client
 # Version: 0.5.2
+# Platforms: linux/amd64, linux/arm64
 # =============================================================================
+
+# OCI Image Labels
+LABEL org.opencontainers.image.title="Slime Arena Monolith Full"
+LABEL org.opencontainers.image.description="Slime Arena all-in-one container: PostgreSQL + Redis + MetaServer + MatchServer + Client. Multi-platform support: AMD64 (Intel/AMD) and ARM64 (Apple Silicon M1-M4, AWS Graviton). Perfect for quick demos and testing."
+LABEL org.opencontainers.image.vendor="komleff"
+LABEL org.opencontainers.image.source="https://github.com/komleff/slime-arena"
+LABEL org.opencontainers.image.documentation="https://github.com/komleff/slime-arena#docker"
+LABEL org.opencontainers.image.licenses="MIT"
 
 # -----------------------------------------------------------------------------
 # Stage 1: Builder


### PR DESCRIPTION
## Описание

Добавлены OCI labels во все три Dockerfile для отображения описания в GHCR.

### Изменения

- **app.Dockerfile** — добавлены labels
- **db.Dockerfile** — добавлены labels  
- **monolith-full.Dockerfile** — добавлены labels

### Labels

| Label | Описание |
|-------|----------|
| \	itle\ | Название образа |
| \description\ | Описание с AMD64 + ARM64 (Apple Silicon M1-M4, AWS Graviton) |
| \endor\ | komleff |
| \source\ | Ссылка на репозиторий |
| \documentation\ | Ссылка на секцию Docker в README |
| \licenses\ | MIT |

### Результат

После мержа и сборки CI эти описания появятся на страницах пакетов в GHCR:
- https://github.com/users/komleff/packages/container/package/slime-arena-app
- https://github.com/users/komleff/packages/container/package/slime-arena-db
- https://github.com/users/komleff/packages/container/package/slime-arena-monolith-full