### PR TITLE
refactor(server): extract AbilityActivationSystem from ArenaRoom

### DIFF
--- a/server/src/rooms/ArenaRoom.ts
+++ b/server/src/rooms/ArenaRoom.ts
@@ -2757,7 +2757,7 @@ export class ArenaRoom extends Room<GameState> {
         };
     }
 
-    private clampPointToWorld(x: number, y: number) {
+    clampPointToWorld(x: number, y: number) {
         const world = this.balance.worldPhysics;
         if (world.worldShape === "circle") {
             const radius = world.radiusM ?? this.balance.world.mapSize / 2;
@@ -2846,7 +2846,7 @@ export class ArenaRoom extends Room<GameState> {
         this.matchId = randomUUID();
     }
 
-    private logTelemetry(event: string, data?: Record<string, unknown>, player?: Player) {
+    logTelemetry(event: string, data?: Record<string, unknown>, player?: Player) {
         if (!this.telemetry) return;
         this.telemetry.log({
             event,

--- a/server/src/rooms/systems/abilityActivationSystem.ts
+++ b/server/src/rooms/systems/abilityActivationSystem.ts
@@ -264,7 +264,7 @@ function activateDash(
     const rawTargetX = player.x + Math.cos(angle) * distance;
     const rawTargetY = player.y + Math.sin(angle) * distance;
 
-    // Clamp к границам мира
+    // Ограничение к границам мира
     const clamped = room.clampPointToWorld(rawTargetX, rawTargetY);
     player.dashTargetX = clamped.x;
     player.dashTargetY = clamped.y;


### PR DESCRIPTION
## Summary
- Извлечение логики активации умений (~600 LOC) из ArenaRoom.ts в отдельный модуль abilityActivationSystem.ts
- ArenaRoom.ts делегирует вызовы модулю через wrapper-методы
- Уменьшение ArenaRoom.ts с ~3400 до ~2900 строк (-500 LOC)

## Changes
- **New:** `server/src/rooms/systems/abilityActivationSystem.ts` — модуль активации умений
- **Modified:** `server/src/rooms/ArenaRoom.ts` — wrapper-методы для делегации

### Перенесённые функции:
- `activateAbility` — основная точка входа активации умения
- `activateDash`, `activateShield`, `activateSlow`, `activateProjectile`, `activateMagnet`, `activateSpit`, `activateBomb`, `activatePush`, `activateMine`
- `resetAbilityCooldowns`, `setAbilityLevelForSlot`, `getAbilityLevelForSlot`
- `applyPushWave` — волна отталкивания
- Helper-функции для кулдаунов и double ability

## Test plan
- [x] `npm run build` — компиляция успешна
- [x] `npm run test` — все тесты проходят (determinism, orb-bite, arena-generation)

## Related
Part of God-object decomposition task `slime-arena-ar1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)