### PR TITLE
feat(docker): include local database data in container build

### DIFF
--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -1,7 +1,7 @@
 # =============================================================================
 # Slime Arena App Container
 # Multi-stage production build for MetaServer + MatchServer + Client
-# Version: 0.7.3
+# Version: 0.7.5
 # Platforms: linux/amd64, linux/arm64
 # =============================================================================
 
@@ -56,7 +56,7 @@ LABEL org.opencontainers.image.title="Slime Arena App"
 LABEL org.opencontainers.image.description="Slime Arena game server bundle: MetaServer + MatchServer + Client"
 LABEL org.opencontainers.image.vendor="komleff"
 LABEL org.opencontainers.image.source="https://github.com/komleff/slime-arena"
-LABEL org.opencontainers.image.version="0.7.3"
+LABEL org.opencontainers.image.version="0.7.5"
 LABEL org.opencontainers.image.licenses="MIT"
 
 WORKDIR /app

--- a/docker/db.Dockerfile
+++ b/docker/db.Dockerfile
@@ -1,7 +1,7 @@
 # =============================================================================
 # Slime Arena DB Container
 # PostgreSQL + Redis in one container
-# Version: 0.7.3
+# Version: 0.7.5
 # Platforms: linux/amd64, linux/arm64
 # =============================================================================
 
@@ -12,7 +12,7 @@ LABEL org.opencontainers.image.title="Slime Arena DB"
 LABEL org.opencontainers.image.description="Slime Arena database bundle: PostgreSQL 16 + Redis"
 LABEL org.opencontainers.image.vendor="komleff"
 LABEL org.opencontainers.image.source="https://github.com/komleff/slime-arena"
-LABEL org.opencontainers.image.version="0.7.3"
+LABEL org.opencontainers.image.version="0.7.5"
 LABEL org.opencontainers.image.licenses="MIT"
 
 # Install PostgreSQL, Redis, supervisord, and utilities
@@ -39,6 +39,10 @@ COPY docker/supervisord-db.conf /etc/supervisord.conf
 # Copy entrypoint script and fix line endings (Windows CRLF -> Unix LF)
 COPY docker/entrypoint-db.sh /entrypoint.sh
 RUN sed -i 's/\r$//' /entrypoint.sh && chmod +x /entrypoint.sh
+
+# Copy seed data for initial database population
+RUN mkdir -p /docker-entrypoint-initdb.d
+COPY docker/seed-data.sql /docker-entrypoint-initdb.d/seed-data.sql
 
 # Expose ports:
 # 5432 - PostgreSQL

--- a/docker/entrypoint-db.sh
+++ b/docker/entrypoint-db.sh
@@ -63,6 +63,13 @@ fi
 if ! su-exec postgres psql -tAc "SELECT 1 FROM pg_database WHERE datname='$DB_NAME'" | grep -q 1; then
     echo "[PostgreSQL] Creating database '$DB_NAME'..."
     su-exec postgres psql -c "CREATE DATABASE $DB_NAME OWNER $DB_USER"
+
+    # Load seed data if available (only on fresh database)
+    if [ -f /docker-entrypoint-initdb.d/seed-data.sql ]; then
+        echo "[Seed] Loading seed data..."
+        su-exec postgres psql -d "$DB_NAME" -f /docker-entrypoint-initdb.d/seed-data.sql
+        echo "[Seed] Done."
+    fi
 else
     echo "[PostgreSQL] Database '$DB_NAME' already exists"
 fi

--- a/docker/monolith-full.Dockerfile
+++ b/docker/monolith-full.Dockerfile
@@ -1,7 +1,7 @@
 # =============================================================================
 # Slime Arena Monolith Full Container
 # All-in-One: PostgreSQL + Redis + MetaServer + MatchServer + Client
-# Version: 0.7.3
+# Version: 0.7.5
 # Platforms: linux/amd64, linux/arm64
 # =============================================================================
 
@@ -56,7 +56,7 @@ LABEL org.opencontainers.image.title="Slime Arena Monolith Full"
 LABEL org.opencontainers.image.description="Slime Arena all-in-one container: PostgreSQL + Redis + MetaServer + MatchServer + Client"
 LABEL org.opencontainers.image.vendor="komleff"
 LABEL org.opencontainers.image.source="https://github.com/komleff/slime-arena"
-LABEL org.opencontainers.image.version="0.7.3"
+LABEL org.opencontainers.image.version="0.7.5"
 LABEL org.opencontainers.image.licenses="MIT"
 
 WORKDIR /app
@@ -118,6 +118,10 @@ COPY docker/supervisord.conf /etc/supervisord.conf
 # Copy entrypoint script and fix line endings (Windows CRLF -> Unix LF)
 COPY docker/entrypoint-full.sh /entrypoint.sh
 RUN sed -i 's/\r$//' /entrypoint.sh && chmod +x /entrypoint.sh
+
+# Copy seed data for initial database population
+RUN mkdir -p /docker-entrypoint-initdb.d
+COPY docker/seed-data.sql /docker-entrypoint-initdb.d/seed-data.sql
 
 # Expose ports:
 # 3000 - MetaServer (HTTP API)

--- a/docker/seed-data.sql
+++ b/docker/seed-data.sql
@@ -1,211 +1,137 @@
--- =============================================================================
--- Slime Arena Initial Data Seed
--- Version: 0.7.4
--- Description: Seeds test players with ratings for development
--- =============================================================================
+--
+-- PostgreSQL database dump
+-- Slime Arena v0.7.5 - exported 2026-02-02
+--
 
--- First, ensure uuid-ossp extension is available
-CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+-- Dumped from database version 16.11
+-- Dumped by pg_dump version 16.11
 
--- =============================================================================
--- First Player: Дмитрий Комлев (Yandex OAuth)
--- =============================================================================
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
 
--- Generate a consistent UUID for the first player
-DO $$
-DECLARE
-    first_user_id UUID := '41d215cb-6657-4ea9-960e-a64c668c9ac3';
-    first_match_id UUID := 'fbb14f6c-fdbd-4c97-b199-2859c1980a1b';
-BEGIN
-    -- Insert user (if not exists)
-    INSERT INTO users (
-        id,
-        nickname,
-        is_anonymous,
-        is_banned,
-        avatar_url,
-        registration_skin_id,
-        created_at,
-        updated_at
-    ) VALUES (
-        first_user_id,
-        'Дмитрий Комлев',
-        FALSE,
-        FALSE,
-        'https://avatars.yandex.net/get-yapic/0/0-0/islands-200',
-        'slime_green',
-        NOW(),
-        NOW()
-    )
-    ON CONFLICT (id) DO NOTHING;
+--
+-- Data for Name: match_results; Type: TABLE DATA; Schema: public; Owner: -
+--
 
-    -- Insert OAuth link (Yandex)
-    INSERT INTO oauth_links (
-        user_id,
-        auth_provider,
-        provider_user_id,
-        created_at
-    ) VALUES (
-        first_user_id,
-        'yandex',
-        'yandex_seed_user_001',
-        NOW()
-    )
-    ON CONFLICT (user_id, auth_provider) DO NOTHING;
+INSERT INTO public.match_results VALUES ('70d611a6-7fad-4a80-9740-2ae264b021f0', 'arena', '2026-01-31 14:40:38.145', '2026-01-31 14:41:13.193', '1.0.0', '0.3.1', '{"matchStats": {"totalKills": 0, "matchDurationMs": 30000, "totalBubblesCollected": 0}, "playerResults": [{"level": 5, "isDead": false, "classId": 2, "finalMass": 1015.6874071361982, "killCount": 0, "placement": 1, "sessionId": "IoG5dgyDv", "deathCount": 0}]}', NULL, NULL);
+INSERT INTO public.match_results VALUES ('07a1c9cf-44c4-438e-b203-15ea88921984', 'arena', '2026-01-31 14:43:14.822', '2026-01-31 14:43:48.969', '1.0.0', '0.3.1', '{"matchStats": {"totalKills": 0, "matchDurationMs": 30000, "totalBubblesCollected": 0}, "playerResults": [{"level": 5, "isDead": false, "classId": 2, "finalMass": 1015.1236798474791, "killCount": 0, "placement": 1, "sessionId": "rXfy7q5ZT", "deathCount": 0}]}', NULL, NULL);
+INSERT INTO public.match_results VALUES ('e0cd857b-bb6e-4ddd-82a5-76c21b64fb01', 'arena', '2026-01-31 14:47:44.569', '2026-01-31 14:48:19.367', '1.0.0', '0.3.1', '{"matchStats": {"totalKills": 0, "matchDurationMs": 30000, "totalBubblesCollected": 0}, "playerResults": [{"level": 4, "isDead": false, "classId": 2, "finalMass": 551.2804036383518, "killCount": 0, "placement": 1, "sessionId": "8t4O-ObVO", "deathCount": 0}]}', NULL, NULL);
+INSERT INTO public.match_results VALUES ('6335d190-83f7-4580-a144-982742ba0129', 'arena', '2026-01-31 14:52:44.596', '2026-01-31 14:53:19.262', '1.0.0', '0.3.1', '{"matchStats": {"totalKills": 0, "matchDurationMs": 30000, "totalBubblesCollected": 0}, "playerResults": [{"level": 3, "isDead": false, "classId": 2, "finalMass": 366.29165738780716, "killCount": 0, "placement": 1, "sessionId": "yS5spd6we", "deathCount": 0}]}', NULL, NULL);
+INSERT INTO public.match_results VALUES ('a3588b63-2658-4d67-9a31-62a81df0d8fc', 'arena', '2026-01-31 14:59:04.558', '2026-01-31 14:59:39.303', '1.0.0', '0.3.1', '{"matchStats": {"totalKills": 0, "matchDurationMs": 30000, "totalBubblesCollected": 0}, "playerResults": [{"level": 5, "isDead": false, "classId": 2, "finalMass": 1189.0227015825233, "killCount": 0, "placement": 1, "sessionId": "rCKvRUHeb", "deathCount": 0}]}', NULL, NULL);
+INSERT INTO public.match_results VALUES ('317bb80a-4e9c-4649-b481-5c5a5e024bf9', 'arena', '2026-01-31 15:44:28.214', '2026-01-31 15:45:03.1', '1.0.0', '0.3.1', '{"matchStats": {"totalKills": 0, "matchDurationMs": 30000, "totalBubblesCollected": 0}, "playerResults": [{"level": 5, "isDead": false, "classId": 2, "finalMass": 795.194352980757, "killCount": 0, "placement": 1, "sessionId": "WUIxTpmJR", "deathCount": 0}]}', '543d6b8f-46bb-403a-8d16-b13fe399c6ce', '2026-01-31 15:45:16.797685');
+INSERT INTO public.match_results VALUES ('b165b3df-7a8e-478f-bcda-52c5220194f1', 'arena', '2026-01-31 15:46:47.417', '2026-01-31 15:47:22.387', '1.0.0', '0.3.1', '{"matchStats": {"totalKills": 0, "matchDurationMs": 30000, "totalBubblesCollected": 0}, "playerResults": [{"level": 2, "isDead": false, "userId": "9f680a03-6844-4ba9-b8f0-52fa8eb4a7e3", "classId": 2, "finalMass": 280.278582265998, "killCount": 0, "placement": 1, "sessionId": "nXAnXiTjW", "deathCount": 0}]}', NULL, NULL);
+INSERT INTO public.match_results VALUES ('69c8518c-03f8-4808-94a0-b07f5799f021', 'arena', '2026-01-31 15:47:40.793', '2026-01-31 15:48:15.222', '1.0.0', '0.3.1', '{"matchStats": {"totalKills": 0, "matchDurationMs": 30000, "totalBubblesCollected": 0}, "playerResults": [{"level": 6, "isDead": false, "userId": "9f680a03-6844-4ba9-b8f0-52fa8eb4a7e3", "classId": 2, "finalMass": 1544.5617422028488, "killCount": 0, "placement": 1, "sessionId": "nOUP1U7us", "deathCount": 0}]}', NULL, NULL);
+INSERT INTO public.match_results VALUES ('8986c291-69c0-4c3e-8284-cc44db08a736', 'arena', '2026-01-31 15:56:16.087', '2026-01-31 15:56:50.991', '1.0.0', '0.3.1', '{"matchStats": {"totalKills": 0, "matchDurationMs": 30000, "totalBubblesCollected": 0}, "playerResults": [{"level": 3, "isDead": false, "classId": 2, "finalMass": 400.1918066040376, "killCount": 0, "placement": 1, "sessionId": "3Jqz32N81", "deathCount": 0}]}', '983b4e9a-40fc-40b5-98e4-b820cc9007a2', NULL);
+INSERT INTO public.match_results VALUES ('b3707afb-2ea0-4ac1-a651-34cea3065b7c', 'arena', '2026-01-31 16:01:53.491', '2026-01-31 16:02:27.558', '1.0.0', '0.3.1', '{"matchStats": {"totalKills": 0, "matchDurationMs": 30000, "totalBubblesCollected": 0}, "playerResults": [{"level": 4, "isDead": false, "classId": 1, "finalMass": 501.41969342367724, "killCount": 0, "placement": 1, "sessionId": "Try5-NLls", "deathCount": 0}]}', 'ecec237a-8b2c-40cc-bebe-638f3ce66bb6', NULL);
+INSERT INTO public.match_results VALUES ('6bee7e05-f132-41c1-bc5a-39869f28a44b', 'arena', '2026-01-31 16:05:53.768', '2026-01-31 16:06:28.277', '1.0.0', '0.3.1', '{"matchStats": {"totalKills": 0, "matchDurationMs": 30000, "totalBubblesCollected": 0}, "playerResults": [{"level": 4, "isDead": false, "userId": "9f680a03-6844-4ba9-b8f0-52fa8eb4a7e3", "classId": 2, "finalMass": 628.8088021236723, "killCount": 0, "placement": 1, "sessionId": "tzqruGrB3", "deathCount": 0}]}', NULL, NULL);
+INSERT INTO public.match_results VALUES ('75a7d134-ec58-4d9d-a0be-a0510a9ac632', 'arena', '2026-01-31 17:05:53.438', '2026-01-31 17:06:29.257', '1.0.0', '0.3.1', '{"matchStats": {"totalKills": 0, "matchDurationMs": 30000, "totalBubblesCollected": 0}, "playerResults": [{"level": 2, "isDead": false, "userId": "9f680a03-6844-4ba9-b8f0-52fa8eb4a7e3", "classId": 2, "finalMass": 139.88310695608322, "killCount": 0, "placement": 2, "sessionId": "-2sHjX9y2", "deathCount": 0}, {"level": 2, "isDead": false, "classId": 0, "finalMass": 262.0719907020857, "killCount": 0, "placement": 1, "sessionId": "KwrCCvY8C", "deathCount": 0, "guestSubjectId": "27c0d66f-5d20-4c42-a074-552cca2fbaf1"}]}', '27c0d66f-5d20-4c42-a074-552cca2fbaf1', NULL);
+INSERT INTO public.match_results VALUES ('a1c38db3-abc8-4ebb-895d-961d3da2aff3', 'arena', '2026-01-31 17:07:05.699', '2026-01-31 17:07:41.307', '1.0.0', '0.3.1', '{"matchStats": {"totalKills": 0, "matchDurationMs": 30000, "totalBubblesCollected": 0}, "playerResults": [{"level": 1, "isDead": false, "userId": "9f680a03-6844-4ba9-b8f0-52fa8eb4a7e3", "classId": 2, "finalMass": 59.84010634711229, "killCount": 0, "placement": 2, "sessionId": "LZx6ZiNv6", "deathCount": 0}, {"level": 3, "isDead": false, "classId": 0, "finalMass": 444.66036926731874, "killCount": 0, "placement": 1, "sessionId": "Bvl-boAGh", "deathCount": 0, "guestSubjectId": "cb4a6c4d-3e64-4cc7-a9cb-26302e60cf13"}]}', 'cb4a6c4d-3e64-4cc7-a9cb-26302e60cf13', NULL);
+INSERT INTO public.match_results VALUES ('73efb1ee-3760-4844-b945-65fa277c83fd', 'arena', '2026-01-31 17:07:58.861', '2026-01-31 17:08:34.518', '1.0.0', '0.3.1', '{"matchStats": {"totalKills": 0, "matchDurationMs": 30000, "totalBubblesCollected": 0}, "playerResults": [{"level": 4, "isDead": false, "userId": "9f680a03-6844-4ba9-b8f0-52fa8eb4a7e3", "classId": 2, "finalMass": 666.5335054575711, "killCount": 0, "placement": 1, "sessionId": "3R5ek3OKp", "deathCount": 0}, {"level": 1, "isDead": false, "classId": 0, "finalMass": 69.82012630051884, "killCount": 0, "placement": 2, "sessionId": "CZbQFwzDi", "deathCount": 0, "guestSubjectId": "cb4a6c4d-3e64-4cc7-a9cb-26302e60cf13"}]}', 'cb4a6c4d-3e64-4cc7-a9cb-26302e60cf13', NULL);
+INSERT INTO public.match_results VALUES ('2dd09ff6-cb8c-4c0f-bd0c-be5f8a501d9d', 'arena', '2026-01-31 17:10:09.772', '2026-01-31 17:10:44.666', '1.0.0', '0.3.1', '{"matchStats": {"totalKills": 0, "matchDurationMs": 30000, "totalBubblesCollected": 0}, "playerResults": [{"level": 4, "isDead": false, "classId": 1, "finalMass": 575.1411543401057, "killCount": 0, "placement": 1, "sessionId": "3ZRQxMMEK", "deathCount": 0, "guestSubjectId": "83b734f5-b272-406d-9120-f651e2febba8"}]}', '83b734f5-b272-406d-9120-f651e2febba8', NULL);
+INSERT INTO public.match_results VALUES ('9b8afd43-5543-49cd-98de-92dc6906e6c6', 'arena', '2026-01-31 17:11:27.625', '2026-01-31 17:12:01.985', '1.0.0', '0.3.1', '{"matchStats": {"totalKills": 0, "matchDurationMs": 30000, "totalBubblesCollected": 0}, "playerResults": [{"level": 2, "isDead": false, "userId": "9f680a03-6844-4ba9-b8f0-52fa8eb4a7e3", "classId": 2, "finalMass": 271.07905410652774, "killCount": 0, "placement": 1, "sessionId": "iIxzm4xMi", "deathCount": 0}]}', NULL, NULL);
+INSERT INTO public.match_results VALUES ('9ec4c764-3c04-453a-a8fe-fb111a414d25', 'arena', '2026-01-31 17:18:05.548', '2026-01-31 17:18:39.689', '1.0.0', '0.3.1', '{"matchStats": {"totalKills": 0, "matchDurationMs": 30000, "totalBubblesCollected": 0}, "playerResults": [{"level": 5, "isDead": false, "classId": 2, "finalMass": 895.4465218142985, "killCount": 0, "placement": 1, "sessionId": "dhkk9vMiM", "deathCount": 0, "guestSubjectId": "06716f3b-364d-4aa1-a14c-e98e7acc0e87"}]}', '06716f3b-364d-4aa1-a14c-e98e7acc0e87', NULL);
+INSERT INTO public.match_results VALUES ('a9b28b36-53e1-4025-8f42-6a51b5bef062', 'arena', '2026-01-31 17:22:24.974', '2026-01-31 17:22:59.411', '1.0.0', '0.3.1', '{"matchStats": {"totalKills": 0, "matchDurationMs": 30000, "totalBubblesCollected": 0}, "playerResults": [{"level": 6, "isDead": false, "classId": 2, "finalMass": 1578.6686966579414, "killCount": 0, "placement": 1, "sessionId": "LVKWrQf_8", "deathCount": 0, "guestSubjectId": "44238dbd-2ffb-4e47-bca3-dd8c3f383180"}]}', '44238dbd-2ffb-4e47-bca3-dd8c3f383180', NULL);
+INSERT INTO public.match_results VALUES ('34583b26-3ad9-4109-8677-ff7ce26d3a82', 'arena', '2026-01-31 17:39:48.939', '2026-01-31 17:40:23.699', '1.0.0', '0.3.1', '{"matchStats": {"totalKills": 0, "matchDurationMs": 30000, "totalBubblesCollected": 0}, "playerResults": [{"level": 3, "isDead": false, "userId": "41d215cb-6657-4ea9-960e-a64c668c9ac3", "classId": 2, "finalMass": 446.18784703510727, "killCount": 0, "placement": 1, "sessionId": "bqb_4XFTZ", "deathCount": 0}]}', NULL, NULL);
+INSERT INTO public.match_results VALUES ('195f87be-e82d-482d-9366-53daec32b073', 'arena', '2026-01-31 17:42:54.7', '2026-01-31 17:43:29.287', '1.0.0', '0.3.1', '{"matchStats": {"totalKills": 0, "matchDurationMs": 30000, "totalBubblesCollected": 0}, "playerResults": [{"level": 3, "isDead": false, "userId": "41d215cb-6657-4ea9-960e-a64c668c9ac3", "classId": 2, "finalMass": 433.8044170262469, "killCount": 0, "placement": 1, "sessionId": "TbJv368Tx", "deathCount": 0}]}', NULL, NULL);
+INSERT INTO public.match_results VALUES ('01035dbc-cea5-44f2-b1e1-6e74db9d7742', 'arena', '2026-01-31 18:12:17.096', '2026-01-31 18:12:51.759', '1.0.0', '0.3.1', '{"matchStats": {"totalKills": 0, "matchDurationMs": 30000, "totalBubblesCollected": 0}, "playerResults": [{"level": 4, "isDead": false, "userId": "41d215cb-6657-4ea9-960e-a64c668c9ac3", "classId": 2, "finalMass": 676.6311382258614, "killCount": 0, "placement": 1, "sessionId": "9EslhKfPX", "deathCount": 0}]}', NULL, NULL);
+INSERT INTO public.match_results VALUES ('fbfa6e5d-6e01-4eb1-bbe9-aefb908dba21', 'arena', '2026-01-31 17:25:28.025', '2026-01-31 17:26:02.202', '1.0.0', '0.3.1', '{"matchStats": {"totalKills": 0, "matchDurationMs": 30000, "totalBubblesCollected": 0}, "playerResults": [{"level": 6, "isDead": false, "classId": 0, "finalMass": 1264.294920334343, "killCount": 0, "placement": 1, "sessionId": "k2y6wQn_K", "deathCount": 0, "guestSubjectId": "08c59bbf-2efd-44df-b5d4-e7e56a86b325"}]}', '08c59bbf-2efd-44df-b5d4-e7e56a86b325', NULL);
+INSERT INTO public.match_results VALUES ('d43c4d85-db69-4802-8d8f-cd10c707016d', 'arena', '2026-02-01 12:10:00.054', '2026-02-01 12:10:34.101', '1.0.0', '0.3.1', '{"matchStats": {"totalKills": 0, "matchDurationMs": 30000, "totalBubblesCollected": 0}, "playerResults": [{"level": 5, "isDead": false, "classId": 1, "finalMass": 1003.3731457881746, "killCount": 0, "placement": 1, "sessionId": "HxXumOQ4w", "deathCount": 0, "guestSubjectId": "b931d032-304c-4925-ba5d-21aaf20f1409"}]}', 'b931d032-304c-4925-ba5d-21aaf20f1409', NULL);
+INSERT INTO public.match_results VALUES ('d24109a7-8c54-42da-8125-cff4222f131c', 'arena', '2026-02-01 12:12:18.525', '2026-02-01 12:12:52.501', '1.0.0', '0.3.1', '{"matchStats": {"totalKills": 0, "matchDurationMs": 30000, "totalBubblesCollected": 0}, "playerResults": [{"level": 4, "isDead": false, "classId": 2, "finalMass": 557.893371077147, "killCount": 0, "placement": 1, "sessionId": "59phTtWds", "deathCount": 0, "guestSubjectId": "08ce5260-6d23-442f-9e41-70124a0ef764"}]}', '08ce5260-6d23-442f-9e41-70124a0ef764', '2026-02-01 12:13:53.623188');
+INSERT INTO public.match_results VALUES ('fbb14f6c-fdbd-4c97-b199-2859c1980a1b', 'arena', '2026-01-31 17:29:06.862', '2026-01-31 17:29:41.21', '1.0.0', '0.3.1', '{"matchStats": {"totalKills": 0, "matchDurationMs": 30000, "totalBubblesCollected": 0}, "playerResults": [{"level": 4, "isDead": false, "classId": 2, "finalMass": 666.6213525884627, "killCount": 0, "placement": 1, "sessionId": "JdsdY3IWN", "deathCount": 0, "guestSubjectId": "12953a37-844d-4317-b8b4-2cc03e6b1ab8"}]}', '12953a37-844d-4317-b8b4-2cc03e6b1ab8', '2026-01-31 17:29:53.355492');
+INSERT INTO public.match_results VALUES ('d054eaa9-e442-4ebf-ab1b-81b46a077020', 'arena', '2026-01-31 17:30:14.934', '2026-01-31 17:30:49.431', '1.0.0', '0.3.1', '{"matchStats": {"totalKills": 0, "matchDurationMs": 30000, "totalBubblesCollected": 0}, "playerResults": [{"level": 6, "isDead": false, "userId": "41d215cb-6657-4ea9-960e-a64c668c9ac3", "classId": 2, "finalMass": 1227.3439707351833, "killCount": 0, "placement": 1, "sessionId": "HO1_ovybz", "deathCount": 0}]}', NULL, NULL);
+INSERT INTO public.match_results VALUES ('71b9d506-bcc5-4c87-b549-1c857d9e5a69', 'arena', '2026-01-31 17:31:03.657', '2026-01-31 17:31:37.886', '1.0.0', '0.3.1', '{"matchStats": {"totalKills": 0, "matchDurationMs": 30000, "totalBubblesCollected": 0}, "playerResults": [{"level": 5, "isDead": false, "userId": "41d215cb-6657-4ea9-960e-a64c668c9ac3", "classId": 2, "finalMass": 828.9309083438022, "killCount": 0, "placement": 1, "sessionId": "YKiMuBmMi", "deathCount": 0}]}', NULL, NULL);
+INSERT INTO public.match_results VALUES ('68b61524-d9ec-4b65-b144-c3ddd1b25ce6', 'arena', '2026-02-01 12:22:36.491', '2026-02-01 12:23:10.255', '1.0.0', '0.3.1', '{"matchStats": {"totalKills": 0, "matchDurationMs": 30000, "totalBubblesCollected": 0}, "playerResults": [{"level": 4, "isDead": false, "classId": 2, "finalMass": 698.4702529838077, "killCount": 0, "placement": 1, "sessionId": "d_KjWG66c", "deathCount": 0, "guestSubjectId": "b931d032-304c-4925-ba5d-21aaf20f1409"}]}', 'b931d032-304c-4925-ba5d-21aaf20f1409', NULL);
+INSERT INTO public.match_results VALUES ('03dc207f-8468-4c1c-8161-ec237ddb5223', 'arena', '2026-02-01 12:27:57.614', '2026-02-01 12:28:32.104', '1.0.0', '0.3.1', '{"matchStats": {"totalKills": 0, "matchDurationMs": 30000, "totalBubblesCollected": 0}, "playerResults": [{"level": 3, "isDead": false, "classId": 2, "finalMass": 458.7204776590346, "killCount": 0, "placement": 1, "sessionId": "RKhnOZo14", "deathCount": 0, "guestSubjectId": "f4032813-f182-4873-b09e-a48af89f90b6"}]}', 'f4032813-f182-4873-b09e-a48af89f90b6', NULL);
+INSERT INTO public.match_results VALUES ('d6e45bf3-6b8a-408d-8da7-1d00b84ec92f', 'arena', '2026-02-01 12:34:24.14', '2026-02-01 12:34:58.29', '1.0.0', '0.3.1', '{"matchStats": {"totalKills": 0, "matchDurationMs": 30000, "totalBubblesCollected": 0}, "playerResults": [{"level": 3, "isDead": false, "userId": "41d215cb-6657-4ea9-960e-a64c668c9ac3", "classId": 2, "finalMass": 491.3257148954538, "killCount": 0, "placement": 1, "sessionId": "OMo67HvGM", "deathCount": 0}]}', NULL, NULL);
+INSERT INTO public.match_results VALUES ('550be1ba-4c99-4b20-94ac-0dd13d2a9721', 'arena', '2026-02-01 12:35:25.098', '2026-02-01 12:35:59.927', '1.0.0', '0.3.1', '{"matchStats": {"totalKills": 0, "matchDurationMs": 30000, "totalBubblesCollected": 0}, "playerResults": [{"level": 7, "isDead": false, "classId": 0, "finalMass": 2082.4585308248315, "killCount": 0, "placement": 1, "sessionId": "Bui4JUFkA", "deathCount": 0, "guestSubjectId": "965633d6-426e-4e8e-81ac-ab31cffb18fc"}]}', '965633d6-426e-4e8e-81ac-ab31cffb18fc', NULL);
+INSERT INTO public.match_results VALUES ('03ba37a0-f9b6-47c0-9e42-be1762389a21', 'arena', '2026-02-01 17:34:11.319', '2026-02-01 17:34:47.995', '1.0.0', '0.3.1', '{"matchStats": {"totalKills": 0, "matchDurationMs": 30000, "totalBubblesCollected": 0}, "playerResults": [{"level": 3, "isDead": false, "classId": 2, "finalMass": 307.1655434545938, "killCount": 0, "placement": 1, "sessionId": "azaXvAW6d", "deathCount": 0}]}', NULL, NULL);
+INSERT INTO public.match_results VALUES ('b08a8b70-ea88-4335-a0b0-b2019d6aeda2', 'arena', '2026-02-01 17:38:25.017', '2026-02-01 17:38:59.587', '1.0.0', '0.3.1', '{"matchStats": {"totalKills": 0, "matchDurationMs": 30000, "totalBubblesCollected": 0}, "playerResults": [{"level": 2, "isDead": false, "classId": 0, "finalMass": 201.98117935913174, "killCount": 0, "placement": 1, "sessionId": "tTw2RRYPh", "deathCount": 0, "guestSubjectId": "d89a9dcf-5c1d-43a9-9c5f-eda879a71967"}]}', 'd89a9dcf-5c1d-43a9-9c5f-eda879a71967', NULL);
+INSERT INTO public.match_results VALUES ('19817009-0408-4fdb-913f-57ce8cb5ba80', 'arena', '2026-02-01 17:46:05.125', '2026-02-01 17:46:39.396', '1.0.0', '0.3.1', '{"matchStats": {"totalKills": 0, "matchDurationMs": 30000, "totalBubblesCollected": 0}, "playerResults": [{"level": 6, "isDead": false, "classId": 0, "finalMass": 1627.3464001906393, "killCount": 0, "placement": 1, "sessionId": "0MUwQmd2U", "deathCount": 0, "guestSubjectId": "b49a6bd7-e438-48fe-9a4b-34a0405bd236"}]}', 'b49a6bd7-e438-48fe-9a4b-34a0405bd236', NULL);
+INSERT INTO public.match_results VALUES ('225ec812-c9b5-4cd0-aa3a-506ffb952e11', 'arena', '2026-02-01 18:02:42.16', '2026-02-01 18:03:20.469', '1.0.0', '0.3.1', '{"matchStats": {"totalKills": 0, "matchDurationMs": 30000, "totalBubblesCollected": 0}, "playerResults": [{"level": 4, "isDead": false, "classId": 0, "finalMass": 499.20015474738165, "killCount": 0, "placement": 1, "sessionId": "SE5L99vGz", "deathCount": 0}]}', NULL, NULL);
+INSERT INTO public.match_results VALUES ('9e1f328c-345a-45c1-ab32-2cc96f24b966', 'arena', '2026-02-01 18:03:38.891', '2026-02-01 18:04:20.413', '1.0.0', '0.3.1', '{"matchStats": {"totalKills": 0, "matchDurationMs": 30000, "totalBubblesCollected": 0}, "playerResults": [{"level": 1, "isDead": true, "classId": -1, "finalMass": 100, "killCount": 0, "placement": 1, "sessionId": "SE5L99vGz", "deathCount": 0}]}', NULL, NULL);
+INSERT INTO public.match_results VALUES ('e32acc19-c95b-403c-9bf4-03b7fd9f86bd', 'arena', '2026-02-01 18:38:49.081', '2026-02-01 18:39:23.141', '1.0.0', '0.3.1', '{"matchStats": {"totalKills": 0, "matchDurationMs": 30000, "totalBubblesCollected": 0}, "playerResults": [{"level": 6, "isDead": false, "userId": "41d215cb-6657-4ea9-960e-a64c668c9ac3", "classId": 2, "finalMass": 1646.7802770453065, "killCount": 0, "placement": 1, "sessionId": "t8vHf5bhc", "deathCount": 0}]}', NULL, NULL);
+INSERT INTO public.match_results VALUES ('0ffb32e8-34a6-47c0-a402-063212badd8e', 'arena', '2026-02-01 18:35:17.181', '2026-02-01 18:35:53.35', '1.0.0', '0.3.1', '{"matchStats": {"totalKills": 0, "matchDurationMs": 30000, "totalBubblesCollected": 0}, "playerResults": [{"level": 7, "isDead": false, "classId": 2, "finalMass": 2544.7593225355668, "killCount": 0, "placement": 1, "sessionId": "lQBJCtaA6", "deathCount": 0, "guestSubjectId": "2759a0d6-add6-4b94-8e2d-f5b07d7cdd1c"}]}', '2759a0d6-add6-4b94-8e2d-f5b07d7cdd1c', '2026-02-01 18:42:58.249572');
+INSERT INTO public.match_results VALUES ('ffbc2955-fc45-477f-a146-ca7de7bb8742', 'arena', '2026-02-01 18:43:21.832', '2026-02-01 18:43:58.08', '1.0.0', '0.3.1', '{"matchStats": {"totalKills": 0, "matchDurationMs": 30000, "totalBubblesCollected": 0}, "playerResults": [{"level": 2, "isDead": false, "userId": "fdf23720-9782-4af0-a6a6-5855e1561e98", "classId": 2, "finalMass": 260.73847793954627, "killCount": 0, "placement": 1, "sessionId": "6V3mfc5Oj", "deathCount": 0}]}', NULL, NULL);
+INSERT INTO public.match_results VALUES ('a2f09f69-cc8e-4065-be89-50c7fafb1b65', 'arena', '2026-02-01 18:44:31.524', '2026-02-01 18:45:08.105', '1.0.0', '0.3.1', '{"matchStats": {"totalKills": 0, "matchDurationMs": 30000, "totalBubblesCollected": 0}, "playerResults": [{"level": 3, "isDead": false, "userId": "fdf23720-9782-4af0-a6a6-5855e1561e98", "classId": 2, "finalMass": 411.13983080052486, "killCount": 0, "placement": 1, "sessionId": "tiMvttHu5", "deathCount": 0}]}', NULL, NULL);
+INSERT INTO public.match_results VALUES ('a61d4153-afad-4b46-906e-993f83d4827d', 'arena', '2026-02-01 18:45:25.845', '2026-02-01 18:46:01.941', '1.0.0', '0.3.1', '{"matchStats": {"totalKills": 0, "matchDurationMs": 30000, "totalBubblesCollected": 0}, "playerResults": [{"level": 4, "isDead": false, "userId": "fdf23720-9782-4af0-a6a6-5855e1561e98", "classId": 2, "finalMass": 592.5155156160325, "killCount": 0, "placement": 1, "sessionId": "tlKabLnuU", "deathCount": 0}]}', NULL, NULL);
+INSERT INTO public.match_results VALUES ('2ec827cf-4bf2-4425-8cf0-a2e361985f0e', 'arena', '2026-02-01 19:13:47.065', '2026-02-01 19:14:21.295', '1.0.0', '0.3.1', '{"matchStats": {"totalKills": 0, "matchDurationMs": 30000, "totalBubblesCollected": 0}, "playerResults": [{"level": 7, "isDead": false, "userId": "41d215cb-6657-4ea9-960e-a64c668c9ac3", "classId": 2, "finalMass": 3652.307689823622, "killCount": 0, "placement": 1, "sessionId": "WRTEqu1WT", "deathCount": 0}]}', NULL, NULL);
+INSERT INTO public.match_results VALUES ('4fc8ecdc-1750-4f7c-8540-75a957a73e40', 'arena', '2026-02-01 19:16:03.685', '2026-02-01 19:17:45.46', '1.0.0', '0.3.1', '{"matchStats": {"totalKills": 0, "matchDurationMs": 90000, "totalBubblesCollected": 0}, "playerResults": [{"level": 9, "isDead": false, "userId": "41d215cb-6657-4ea9-960e-a64c668c9ac3", "classId": 2, "finalMass": 5503.143726232629, "killCount": 0, "placement": 1, "sessionId": "v_yyD2gea", "deathCount": 0}]}', NULL, NULL);
 
-    -- Insert leaderboard total mass
-    INSERT INTO leaderboard_total_mass (
-        user_id,
-        total_mass,
-        matches_played,
-        updated_at
-    ) VALUES (
-        first_user_id,
-        2723,
-        3,
-        NOW()
-    )
-    ON CONFLICT (user_id) DO UPDATE SET
-        total_mass = EXCLUDED.total_mass,
-        matches_played = EXCLUDED.matches_played,
-        updated_at = NOW();
 
-    -- Insert leaderboard best mass
-    INSERT INTO leaderboard_best_mass (
-        user_id,
-        best_mass,
-        best_match_id,
-        players_in_match,
-        achieved_at,
-        updated_at
-    ) VALUES (
-        first_user_id,
-        1227,
-        first_match_id,
-        8,
-        NOW(),
-        NOW()
-    )
-    ON CONFLICT (user_id) DO UPDATE SET
-        best_mass = EXCLUDED.best_mass,
-        best_match_id = EXCLUDED.best_match_id,
-        updated_at = NOW();
+--
+-- Data for Name: users; Type: TABLE DATA; Schema: public; Owner: -
+--
 
-    -- Insert rating awards for idempotency
-    INSERT INTO rating_awards (user_id, match_id, awarded_at)
-    VALUES
-        (first_user_id, first_match_id, NOW()),
-        (first_user_id, 'd054eaa9-e442-4ebf-ab1b-81b46a077020', NOW()),
-        (first_user_id, '71b9d506-bcc5-4c87-b549-1c857d9e5a69', NOW())
-    ON CONFLICT (user_id, match_id) DO NOTHING;
+INSERT INTO public.users VALUES ('9bdd1f4c-9509-494a-8504-06ca23b0cff2', 'yandex', '1370653626', 'Andrey Gordeev', 'https://avatars.yandex.net/get-yapic/29310/0o-6/islands-200', 'ru', '2026-02-01 12:13:53.623188', '2026-02-01 12:36:23.514869', '2026-02-01 12:36:23.514869', false, NULL, NULL, false, 'slime_green', 'd24109a7-8c54-42da-8125-cff4222f131c', '2026-02-01 12:13:53.623188');
+INSERT INTO public.users VALUES ('41d215cb-6657-4ea9-960e-a64c668c9ac3', 'yandex', '1588141', 'Дмитрий Комлев', 'https://avatars.yandex.net/get-yapic/28053/12EiIDwfirM9LKYhGbJ2TSbUluE-1/islands-200', 'ru', '2026-01-31 17:29:53.355492', '2026-02-01 17:39:21.095876', '2026-02-01 17:39:21.095876', false, NULL, NULL, false, 'slime_red', 'fbb14f6c-fdbd-4c97-b199-2859c1980a1b', '2026-01-31 17:29:53.355492');
+INSERT INTO public.users VALUES ('fdf23720-9782-4af0-a6a6-5855e1561e98', 'yandex', '2328929672', 'Mongol-911', 'https://avatars.yandex.net/get-yapic/65952/0s-2/islands-200', 'ru', '2026-02-01 18:42:58.249572', '2026-02-01 18:42:58.249572', '2026-02-01 18:42:58.249572', false, NULL, NULL, false, 'slime_blue', '0ffb32e8-34a6-47c0-a402-063212badd8e', '2026-02-01 18:42:58.249572');
 
-    RAISE NOTICE 'First player seeded: Дмитрий Комлев (id: %)', first_user_id;
-    RAISE NOTICE 'Total mass: 2723, Best mass: 1227, Matches: 3';
-END $$;
 
--- =============================================================================
--- Second Player: Андрей Гордеев (Yandex OAuth)
--- =============================================================================
+--
+-- Data for Name: leaderboard_best_mass; Type: TABLE DATA; Schema: public; Owner: -
+--
 
-DO $$
-DECLARE
-    second_user_id UUID := '9bdd1f4c-8a7e-4b3d-9c1e-2f5a8b6c7d8e';
-    second_match_id UUID := 'd24109a7-8c54-42da-8125-cff4222f131c';
-BEGIN
-    -- Insert user (if not exists)
-    INSERT INTO users (
-        id,
-        nickname,
-        is_anonymous,
-        is_banned,
-        avatar_url,
-        registration_skin_id,
-        created_at,
-        updated_at
-    ) VALUES (
-        second_user_id,
-        'gav.andreygordeev',
-        FALSE,
-        FALSE,
-        NULL,
-        'slime_blue',
-        NOW(),
-        NOW()
-    )
-    ON CONFLICT (id) DO NOTHING;
+INSERT INTO public.leaderboard_best_mass VALUES ('9bdd1f4c-9509-494a-8504-06ca23b0cff2', 558, 'd24109a7-8c54-42da-8125-cff4222f131c', 1, '2026-02-01 12:13:53.623188', '2026-02-01 12:13:53.623188');
+INSERT INTO public.leaderboard_best_mass VALUES ('fdf23720-9782-4af0-a6a6-5855e1561e98', 2545, '0ffb32e8-34a6-47c0-a402-063212badd8e', 1, '2026-02-01 18:42:58.249572', '2026-02-01 18:42:58.249572');
+INSERT INTO public.leaderboard_best_mass VALUES ('41d215cb-6657-4ea9-960e-a64c668c9ac3', 5503, '4fc8ecdc-1750-4f7c-8540-75a957a73e40', 1, '2026-02-01 19:17:45.487147', '2026-02-01 19:17:45.487147');
 
-    -- Insert OAuth link (Yandex)
-    INSERT INTO oauth_links (
-        user_id,
-        auth_provider,
-        provider_user_id,
-        created_at
-    ) VALUES (
-        second_user_id,
-        'yandex',
-        '13706536',
-        NOW()
-    )
-    ON CONFLICT (user_id, auth_provider) DO NOTHING;
 
-    -- Insert leaderboard total mass
-    INSERT INTO leaderboard_total_mass (
-        user_id,
-        total_mass,
-        matches_played,
-        updated_at
-    ) VALUES (
-        second_user_id,
-        558,
-        1,
-        NOW()
-    )
-    ON CONFLICT (user_id) DO UPDATE SET
-        total_mass = EXCLUDED.total_mass,
-        matches_played = EXCLUDED.matches_played,
-        updated_at = NOW();
+--
+-- Data for Name: leaderboard_total_mass; Type: TABLE DATA; Schema: public; Owner: -
+--
 
-    -- Insert leaderboard best mass
-    INSERT INTO leaderboard_best_mass (
-        user_id,
-        best_mass,
-        best_match_id,
-        players_in_match,
-        achieved_at,
-        updated_at
-    ) VALUES (
-        second_user_id,
-        558,
-        second_match_id,
-        1,
-        NOW(),
-        NOW()
-    )
-    ON CONFLICT (user_id) DO UPDATE SET
-        best_mass = EXCLUDED.best_mass,
-        best_match_id = EXCLUDED.best_match_id,
-        updated_at = NOW();
+INSERT INTO public.leaderboard_total_mass VALUES ('9bdd1f4c-9509-494a-8504-06ca23b0cff2', 558, 1, '2026-02-01 12:13:53.623188');
+INSERT INTO public.leaderboard_total_mass VALUES ('fdf23720-9782-4af0-a6a6-5855e1561e98', 3810, 4, '2026-02-01 18:46:01.965032');
+INSERT INTO public.leaderboard_total_mass VALUES ('41d215cb-6657-4ea9-960e-a64c668c9ac3', 15573, 10, '2026-02-01 19:17:45.487147');
 
-    RAISE NOTICE 'Second player seeded: gav.andreygordeev (id: %)', second_user_id;
-    RAISE NOTICE 'Total mass: 558, Best mass: 558, Matches: 1';
-END $$;
 
--- =============================================================================
--- Verification
--- =============================================================================
+--
+-- Data for Name: oauth_links; Type: TABLE DATA; Schema: public; Owner: -
+--
 
--- Show seeded data
-SELECT
-    u.id,
-    u.nickname,
-    u.is_anonymous,
-    ol.auth_provider,
-    ltm.total_mass,
-    ltm.matches_played,
-    lbm.best_mass
-FROM users u
-LEFT JOIN oauth_links ol ON u.id = ol.user_id
-LEFT JOIN leaderboard_total_mass ltm ON u.id = ltm.user_id
-LEFT JOIN leaderboard_best_mass lbm ON u.id = lbm.user_id
-WHERE u.nickname IN ('Дмитрий Комлев', 'gav.andreygordeev')
-ORDER BY ltm.total_mass DESC;
+INSERT INTO public.oauth_links VALUES ('c1f51968-9c4c-4763-8f65-e902d3a97276', '41d215cb-6657-4ea9-960e-a64c668c9ac3', 'yandex', '1588141', '2026-01-31 17:29:53.355492');
+INSERT INTO public.oauth_links VALUES ('a3848bc9-04a2-4463-856e-1e6d53e3c418', '9bdd1f4c-9509-494a-8504-06ca23b0cff2', 'yandex', '1370653626', '2026-02-01 12:13:53.623188');
+INSERT INTO public.oauth_links VALUES ('d331477b-88f0-436e-af56-12101a624a20', 'fdf23720-9782-4af0-a6a6-5855e1561e98', 'yandex', '2328929672', '2026-02-01 18:42:58.249572');
+
+
+--
+-- Data for Name: player_ratings; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+
+
+--
+-- Data for Name: profiles; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+INSERT INTO public.profiles VALUES ('9bdd1f4c-9509-494a-8504-06ca23b0cff2', 1, 0, 'slime_green', '2026-02-01 12:13:53.623188', '2026-02-01 12:13:53.623188');
+INSERT INTO public.profiles VALUES ('fdf23720-9782-4af0-a6a6-5855e1561e98', 1, 180, 'slime_blue', '2026-02-01 18:42:58.249572', '2026-02-01 18:46:01.951702');
+INSERT INTO public.profiles VALUES ('41d215cb-6657-4ea9-960e-a64c668c9ac3', 1, 540, 'slime_red', '2026-01-31 17:29:53.355492', '2026-02-01 19:17:45.471846');
+
+
+--
+-- Data for Name: unlocked_items; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+
+
+--
+-- Data for Name: wallets; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+INSERT INTO public.wallets VALUES ('9bdd1f4c-9509-494a-8504-06ca23b0cff2', 0, 0, '2026-02-01 12:13:53.623188');
+INSERT INTO public.wallets VALUES ('fdf23720-9782-4af0-a6a6-5855e1561e98', 90, 0, '2026-02-01 18:46:01.951702');
+INSERT INTO public.wallets VALUES ('41d215cb-6657-4ea9-960e-a64c668c9ac3', 270, 0, '2026-02-01 19:17:45.471846');
+
+
+--
+-- PostgreSQL database dump complete
+--


### PR DESCRIPTION
## Краткое описание

Docker-контейнеры теперь включают текущие данные из локальной PostgreSQL (игроки, лидерборд).

## Изменения

### Экспорт данных
- `docker/seed-data.sql` — экспорт из локальной БД (3 игрока, 43 матча, лидерборды)

### Entrypoint скрипты
- `entrypoint-db.sh` — загрузка seed-data.sql при создании свежей БД
- `entrypoint-full.sh` — загрузка seed после миграций (проверка на пустую таблицу users)

### Dockerfiles
- `db.Dockerfile` — COPY seed-data.sql, version 0.7.5
- `app.Dockerfile` — version 0.7.5
- `monolith-full.Dockerfile` — COPY seed-data.sql, version 0.7.5

## Данные в seed

| Игрок | OAuth | Total Mass | Best Mass |
|-------|-------|------------|-----------|
| Дмитрий Комлев | yandex | 15573 | 5503 |
| Mongol-911 | yandex | 3810 | 2545 |
| Andrey Gordeev | yandex | 558 | 558 |

## Тестирование

```bash
# Сборка
docker build -f docker/db.Dockerfile -t ghcr.io/komleff/slime-arena-db:0.7.5 .
docker build -f docker/app.Dockerfile -t ghcr.io/komleff/slime-arena-app:0.7.5 .

# Проверка данных в контейнере
docker exec -it slime-arena-db psql -U slime -d slime_arena -c "SELECT nickname, total_mass FROM leaderboard_total_mass ORDER BY total_mass DESC;"
```

## Beads

Closes: `slime-arena-rurn`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)